### PR TITLE
feat(car_detail): add details screen with pricing and specs widgets

### DIFF
--- a/lib/core/functions/format_prices_number.dart
+++ b/lib/core/functions/format_prices_number.dart
@@ -1,0 +1,6 @@
+String formatPrice(double price) {
+  return price.toStringAsFixed(2).replaceAllMapped(
+    RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+    (Match m) => "${m[1]},",
+  );
+}

--- a/lib/features/car_detail/widgets/custom_car_title_and_rating.dart
+++ b/lib/features/car_detail/widgets/custom_car_title_and_rating.dart
@@ -1,0 +1,49 @@
+import 'package:auto_swift/core/components/text.dart';
+import 'package:auto_swift/core/helpers/spacing.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class CustomCarTitleAndRating extends StatelessWidget {
+  final String carModel;
+  final String carBrand;
+  const CustomCarTitleAndRating({
+    super.key,
+    required this.carModel,
+    required this.carBrand,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 25).r,
+      child: Row(
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CustomText(text: carModel, fontSize: 22),
+
+              verticalSpace(4),
+              CustomText(text: carBrand, fontFamily: 'Reg'),
+            ],
+          ),
+          Spacer(),
+          Container(
+            padding: EdgeInsets.symmetric(horizontal: 10, vertical: 5).r,
+            decoration: BoxDecoration(
+              color: Colors.white12,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.star, color: Colors.yellow, size: 18.sp),
+                SizedBox(width: 4),
+                CustomText(text: '4.3', color: Colors.yellow, fontSize: 13),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/car_detail/widgets/custom_price_card.dart
+++ b/lib/features/car_detail/widgets/custom_price_card.dart
@@ -1,0 +1,64 @@
+import 'package:auto_swift/core/components/text.dart';
+import 'package:auto_swift/core/functions/format_prices_number.dart';
+import 'package:auto_swift/core/theming/colors/app_colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+
+class CustomPriceCard extends StatelessWidget {
+  final String price;
+  const CustomPriceCard({super.key, required this.price});
+
+  @override
+  Widget build(BuildContext context) {
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Price Row
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            CustomText(
+              text: 'Price',
+              color: Colors.white70,
+              fontFamily: 'Reg',
+              fontSize: 16,
+            ),
+            Padding(
+              padding: const EdgeInsets.only(right: 13),
+              child: CustomText(text: '\$${formatPrice(int.parse(price).toDouble())}', fontSize: 20),
+            ),
+          ],
+        ),
+        const SizedBox(height: 20),
+        // Checkout Row
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            CustomText(
+              text: 'Ckeckout',
+              color: Colors.white70,
+              fontFamily: 'Reg',
+              fontSize: 16,
+            ),
+    
+            ElevatedButton(
+              onPressed: () {},
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.yellow,
+                foregroundColor: Colors.black,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 15, vertical: 8).r,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(30).r,
+                ),
+              ),
+              child: CustomText(text: 'Buy Now', color: AppColors.mainBlack),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/car_detail/widgets/custom_top_bar.dart
+++ b/lib/features/car_detail/widgets/custom_top_bar.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class CustomTopBar extends StatelessWidget {
+  const CustomTopBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        _circleButton(Icons.arrow_back_ios_new, () {
+          Navigator.pop(context);
+        }),
+        Icon(Icons.directions_car, size: 25.sp, color: Colors.white),
+        _circleButton(Icons.star, () {}),
+      ],
+    );
+  }
+}
+
+Widget _circleButton(IconData icon, VoidCallback onTap) {
+  return InkWell(
+    onTap: onTap,
+    borderRadius: BorderRadius.circular(30),
+    child: Container(
+      padding: const EdgeInsets.all(10),
+      decoration: const BoxDecoration(
+        color: Colors.white12,
+        shape: BoxShape.circle,
+      ),
+      child: Icon(icon, color: Colors.white, size: 20),
+    ),
+  );
+}

--- a/lib/features/car_detail/widgets/spec_circle_speed_engin_seats.dart
+++ b/lib/features/car_detail/widgets/spec_circle_speed_engin_seats.dart
@@ -1,0 +1,68 @@
+import 'package:auto_swift/core/components/text.dart' show CustomText;
+import 'package:auto_swift/core/helpers/spacing.dart';
+import 'package:auto_swift/core/theming/colors/app_colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class SpecCircleSpeedEnginSeats extends StatelessWidget {
+  final String carSpeed;
+  final String carEngin;
+  final String carSeats;
+  const SpecCircleSpeedEnginSeats({super.key, required this.carSpeed, required this.carEngin, required this.carSeats});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: [
+        SpecItem(
+          value: "$carSpeed KM/H",
+          label: "Max speed",
+          icon: Icons.speed,
+        ),
+        SpecItem(
+          value: carEngin,
+          label: "Max speed",
+          icon: Icons.speed,
+        ),
+        SpecItem(
+          value: "$carSeats Seats",
+          label: "Max speed",
+          icon: Icons.speed,
+        ),
+      ],
+    );
+  }
+}
+
+class SpecItem extends StatelessWidget {
+  final String value;
+  final String label;
+  final IconData icon;
+  const SpecItem({
+    super.key,
+    required this.value,
+    required this.label,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        CircleAvatar(
+          backgroundColor: AppColors.grayScaleHoder,
+          radius: 21.r,
+          child: CircleAvatar(
+            radius: 20.r,
+            backgroundColor: AppColors.mainDarkGrey,
+            child: Icon(icon, color: Colors.white, size: 30.sp),
+          ),
+        ),
+        verticalSpace(10),
+        CustomText(text: label, fontSize: 12, color: AppColors.grayScaleHoder),
+        CustomText(text: value, fontFamily: 'Reg', fontSize: 14),
+      ],
+    );
+  }
+}

--- a/lib/features/home/widgets/custom_car_card.dart
+++ b/lib/features/home/widgets/custom_car_card.dart
@@ -10,83 +10,93 @@ class CarCard extends StatelessWidget {
   final String carBrand;
   final int seats;
   final double pricePerDay;
+  final void Function()? onTap;
 
   const CarCard({
     super.key,
     required this.imageUrl,
     required this.carBrand,
     required this.seats,
-    required this.pricePerDay,
+    required this.pricePerDay, this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 180.w,
-      // height: 200.h,
-      padding: const EdgeInsets.all(12),
-    decoration:  BoxDecoration(
-              borderRadius: BorderRadius.circular(16).r,
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 180.w,
+        // height: 200.h,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16).r,
 
           gradient: LinearGradient(
-            begin: Alignment.topCenter,   // يبدأ من الأعلى
-            end: Alignment.bottomCenter,  // ينتهي بالأسفل
+            begin: Alignment.topCenter, // يبدأ من الأعلى
+            end: Alignment.bottomCenter, // ينتهي بالأسفل
             colors: [
               Color.fromARGB(255, 70, 69, 69), // لون رمادي فاتح (أعلى)
               Color(0xFF0D0D0D), // لون داكن (أسفل)
             ],
           ),
         ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(12).r,
-              child: Image.network(
-                "${ApiEndPoints.baseUrl}upload/car_image/$imageUrl",
-                height: 90.h,
-                width: double.infinity,
-                fit: BoxFit.cover,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12).r,
+                child: Image.network(
+                  "${ApiEndPoints.baseUrl}upload/car_image/$imageUrl",
+                  height: 90.h,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                ),
               ),
             ),
-          ),
-          verticalSpace(3),
-        CustomText(text: carBrand ,fontSize: 18,fontWeight: FontWeight.bold,color: AppColors.mainWhite,fontFamily: 'Oswald',letterSpace: 1,),
-          verticalSpace(4),
-          Row(
-            children: [
-              const Icon(Icons.event_seat, size: 16, color: Colors.grey),
-              const SizedBox(width: 4),
-              Text(
-                "$seats Seat",
-                style: const TextStyle(color: Colors.grey, fontSize: 13),
-              ),
-            ],
-          ),
-                  verticalSpace(4),
+            verticalSpace(3),
+            CustomText(
+              text: carBrand,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              color: AppColors.mainWhite,
+              fontFamily: 'Oswald',
+              letterSpace: 1,
+            ),
+            verticalSpace(4),
+            Row(
+              children: [
+                const Icon(Icons.event_seat, size: 16, color: Colors.grey),
+                const SizedBox(width: 4),
+                Text(
+                  "$seats Seat",
+                  style: const TextStyle(color: Colors.grey, fontSize: 13),
+                ),
+              ],
+            ),
+            verticalSpace(4),
 
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              CustomText(text: "\$$pricePerDay/D", fontSize: 13,),
-          
-              Container(
-                padding: const EdgeInsets.all(4).r,
-                decoration: BoxDecoration(
-                  color: Colors.blue.withValues(alpha: 0.1),
-                  shape: BoxShape.circle,
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                CustomText(text: "\$$pricePerDay/D", fontSize: 13),
+
+                Container(
+                  padding: const EdgeInsets.all(4).r,
+                  decoration: BoxDecoration(
+                    color: Colors.blue.withValues(alpha: 0.1),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.arrow_forward,
+                    color: Colors.amber,
+                    size: 18.sp,
+                  ),
                 ),
-                child:  Icon(
-                  Icons.arrow_forward,
-                  color: Colors.amber,
-                  size: 18.sp,
-                ),
-              ),
-            ],
-          ),
-        
-        ],
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/home/widgets/custom_cars_grid_view.dart
+++ b/lib/features/home/widgets/custom_cars_grid_view.dart
@@ -1,6 +1,7 @@
 import 'package:auto_swift/features/home/cubit/home_cubit.dart';
 import 'package:auto_swift/features/home/models/car_model.dart';
 import 'package:auto_swift/features/home/widgets/custom_car_card.dart';
+import 'package:auto_swift/features/screens/details_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -12,7 +13,7 @@ class CustomCarsGridView extends StatelessWidget {
     return BlocBuilder<HomeCubit, HomeState>(
       builder: (context, state) {
         return GridView.builder(
-          padding: EdgeInsets.symmetric(vertical: 0 ,horizontal: 0),
+          padding: EdgeInsets.symmetric(vertical: 0, horizontal: 0),
           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: 2,
             childAspectRatio: 1.0,
@@ -27,6 +28,26 @@ class CustomCarsGridView extends StatelessWidget {
               carBrand: car.carBrand!,
               seats: int.parse(car.carSeats!),
               pricePerDay: int.parse(car.carPrice!).toDouble(),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) {
+                      return DetailsScreen(
+                        data: {
+                          "carImage": car.carImage,
+                          "carBrand": car.carBrand,
+                          "carSeats": car.carSeats,
+                          "carPrice": car.carPrice,
+                          "carModel": car.carModel,
+                          "carEngin": car.carEngin,
+                          "carSpeed": car.carSpeed,
+                        },
+                      );
+                    },
+                  ),
+                );
+              },
             );
           },
         );

--- a/lib/features/screens/details_screen.dart
+++ b/lib/features/screens/details_screen.dart
@@ -1,0 +1,88 @@
+import 'package:auto_swift/core/api/api_end_points.dart';
+import 'package:auto_swift/core/helpers/spacing.dart';
+import 'package:auto_swift/core/theming/colors/app_colors.dart';
+import 'package:auto_swift/features/car_detail/widgets/custom_car_title_and_rating.dart';
+import 'package:auto_swift/features/car_detail/widgets/custom_price_card.dart';
+import 'package:auto_swift/features/car_detail/widgets/custom_top_bar.dart';
+import 'package:auto_swift/features/car_detail/widgets/spec_circle_speed_engin_seats.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class DetailsScreen extends StatelessWidget {
+  final Map data;
+  const DetailsScreen({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [Color.fromARGB(255, 33, 32, 32), AppColors.mainBlack],
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            children: [
+              // --------- AppBar ---------
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8).r,
+                child: CustomTopBar(),
+              ),
+
+              // --------- Car Image ---------
+              Expanded(
+                child: Column(
+                  children: [
+                    verticalSpace(20),
+                    SizedBox(
+                      child: Image.network(
+                        "${ApiEndPoints.baseUrl}upload/car_image/${data['carImage']}",
+                        height: 170.h,
+                      ),
+                    ),
+
+                    verticalSpace(20),
+
+                    // Car Title + Rating
+                    CustomCarTitleAndRating(
+                      carModel: data['carModel'],
+                      carBrand: data['carBrand'],
+                    ),
+
+                    verticalSpace(50),
+
+                    // Specs
+                    Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      child: SpecCircleSpeedEnginSeats(
+                        carSpeed: data['carSpeed'],
+                        carEngin: data['carEngin'],
+                        carSeats: data['carSeats'],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // --------- Bottom Checkout ---------
+              Container(
+                padding: const EdgeInsets.all(16).r,
+                margin: EdgeInsets.symmetric(vertical: 30, horizontal: 10).r,
+
+                decoration: BoxDecoration(
+                  color: Color.fromARGB(255, 41, 40, 40),
+                  borderRadius: BorderRadius.circular(20).r,
+                ),
+                child: CustomPriceCard(price: data['carPrice']),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/screens/home_screen.dart
+++ b/lib/features/screens/home_screen.dart
@@ -21,7 +21,7 @@ class HomeScreen extends StatelessWidget {
             begin: Alignment.topCenter, 
             end: Alignment.bottomCenter, 
             colors: [
-              AppColors.mainGrey, 
+              Color.fromARGB(255, 28, 28, 28), 
               AppColors.mainBlack, 
             ],
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -280,6 +280,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: "direct main"
+    description:
+      name: font_awesome_flutter
+      sha256: b738e35f8bb4957896c34957baf922f99c5d415b38ddc8b070d14b7fa95715d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.9.1"
   graphs:
     dependency: transitive
     description:
@@ -368,6 +376,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,8 @@ dependencies:
   image_picker: ^1.1.2
   dropdown_button2: ^2.3.9
   awesome_dialog: ^3.2.1
+  font_awesome_flutter: ^10.9.1
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Added `details_screen.dart` for displaying car details
- Introduced widgets:
  • `custom_car_title_and_rating.dart`
  • `custom_price_card.dart`
  • `custom_top_bar.dart`
  • `spec_circle_speed_engin_seats.dart`
- Created `format_prices_number.dart` helper for price formatting
- Updated `custom_car_card.dart` and `custom_cars_grid_view.dart` to link with details screen
- Adjusted `home_screen.dart` to navigate to details
- Updated dependencies in `pubspec.yaml` and `pubspec.lock`
 **`Car Details Screen 📱`**

![Uploading Screenshot_2025-08-19-12-36-29-86_fe9c936b062201455331bbf5c8184d39-portrait.png…]()

  